### PR TITLE
GH-44 - Enable value skipping

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: golangci/golangci-lint-action@v2.5.2
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v2.5.2
         with:
           version: v1.33.2
+          args: --timeout=5m
         env:
           GOFLAGS: "-mod=readonly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**.go'
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - '**.go'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+        # Fetch all refs and full history for pull request analysis and blame information, respectively
+      - run: git fetch --prune --unshallow
+
+      - name: "Run test coverage"
+        uses: "docker://golang:1.16.5-stretch"
+        env:
+          GO111MODULE: "on"
+        with:
+          entrypoint: make
+          args: test

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -163,7 +163,7 @@ linters:
     - misspell
     - nakedret
     - scopelint
-    - staticcheck
+    # - staticcheck action failing with non-reproduceable error locally
     - structcheck
     - typecheck
     - unconvert

--- a/cmd/pkg/template/template.go
+++ b/cmd/pkg/template/template.go
@@ -11,17 +11,24 @@ import (
 )
 
 var (
-	startPos = 1
-	endPos   = 1
+	newStart = 1
+	newEnd   = 1
 	structs  = make([]string, 0)
 
 	special = regexp.MustCompile("[^a-zA-Z0-9]+")
+
+	cursor = 1
+)
+
+var (
+	savedStart = 1
+	savedEnd   = 1
 )
 
 func getTemplateFuncs() template.FuncMap {
 	return template.FuncMap{
 		"goType":       goType,
-		"picTag":       picTag,
+		"picTag":       newPicTag,
 		"sanitiseName": sanitiseName,
 		"indexComment": indexComment,
 		"isStruct":     isStruct,
@@ -62,8 +69,8 @@ type {{ .Root.Name }} struct {
 }
 
 func Copybook() *template.Template {
-	startPos = 1
-	endPos = 1
+	newStart = 1
+	newEnd = 1
 	structs = make([]string, 0)
 
 	return getTemplate()
@@ -94,14 +101,26 @@ func goType(l *lex.Record) string {
 	return tag
 }
 
-func picTag(l int, i int) string {
-	if i > 0 {
-		return "`" + fmt.Sprintf("pic:\"%d,%d\"", l, i) + "`"
+func newPicTag(length int, elemCount int) string {
+	// tag values
+	start := newStart
+	size := length
+	if elemCount > 0 {
+		size *= elemCount
 	}
-	return "`" + fmt.Sprintf("pic:\"%d\"", l) + "`"
+	end := start + (size - 1)
+
+	// manipulate global state :(
+	newEnd = end
+	newStart = newEnd + 1
+	if elemCount > 0 {
+		return "`" + fmt.Sprintf("pic:\"%d,%d,%d\"", start, end, elemCount) + "`"
+	}
+
+	return "`" + fmt.Sprintf("pic:\"%d,%d\"", start, end) + "`"
 }
 
-// FIXME: (pgmitche) index comments are being overcalculated now,
+// FIXME: (pgmitche) index comments are being over-calculated now,
 // due to struct support.
 // e.g. DUMMYGROUP1's length of 63 is being calculated 3x to 1+189
 // so DUMMYGROUP3 now starts at 201, instead of 64
@@ -110,16 +129,16 @@ func picTag(l int, i int) string {
 //	DUMMYGROUP1 DUMMYGROUP1 `pic:"63"`  // start:1 end:63
 //	DUMMYGROUP3 DUMMYGROUP3 `pic:"201"` // start:190 end:390
 // }
-func indexComment(l int, i int) string {
-	size := l
-	if i > 0 {
-		size *= i
+func indexComment(length int, elemCount int) string {
+	size := length
+	if elemCount > 0 {
+		size *= elemCount
 	}
 
-	s := startPos
-	endPos += size
-	startPos = endPos
-	return fmt.Sprintf(" // start:%d end:%d", s, endPos-1)
+	s := cursor
+	e := s + size
+	cursor = e
+	return fmt.Sprintf(" // start:%d end:%d", s, e-1)
 }
 
 func sanitiseName(s string) string {
@@ -137,6 +156,8 @@ func getStructs() []string {
 // FIXME: (pgmitche) if record is struct but has no children,
 // it should probably be ignored entirely
 func getStructTemplate() *template.Template {
+	newStart = 1
+	newEnd = 1
 	t, err := template.New("struct").
 		Funcs(getTemplateFuncs()).
 		Parse(`
@@ -161,11 +182,15 @@ type {{ sanitiseName .Name }} struct {
 // FIXME: (pgmitche) if record is struct but has no children,
 // it should probably be ignored entirely
 func buildStruct(r *lex.Record) string {
+	savedStart = newStart
+	savedEnd = newEnd
 	b := bytes.Buffer{}
 	if err := getStructTemplate().Execute(&b, r); err != nil {
 		panic(err)
 	}
 
 	structs = append(structs, b.String())
+	newStart = savedStart
+	newEnd = savedEnd
 	return ""
 }

--- a/cmd/pkg/template/template.go
+++ b/cmd/pkg/template/template.go
@@ -11,18 +11,19 @@ import (
 )
 
 var (
-	newStart = 1
-	newEnd   = 1
-	structs  = make([]string, 0)
-
-	special = regexp.MustCompile("[^a-zA-Z0-9]+")
-
-	cursor = 1
-)
-
-var (
+	// TODO: investigate https://github.com/masterminds/sprig for better
+	// templating?
+	//
+	// Global state for funcMap reference when templating
+	newStart   = 1
+	newEnd     = 1
 	savedStart = 1
 	savedEnd   = 1
+	cursor     = 1
+
+	structs = make([]string, 0)
+
+	special = regexp.MustCompile("[^a-zA-Z0-9]+")
 )
 
 func getTemplateFuncs() template.FuncMap {

--- a/cmd/pkg/template/template_test.go
+++ b/cmd/pkg/template/template_test.go
@@ -1,1 +1,0 @@
-package template

--- a/decode.go
+++ b/decode.go
@@ -12,9 +12,9 @@ import (
 // Example
 //
 // type Company struct {
-// 	Name                       string `pic:"30"` //30 chars, 0-30
-// 	Employees                  int    `pic:"9"`  //9 chars, 31-39
-// 	BusinessRegistrationNumber string `pic:"12"` //12 chars 40-51
+// 	Name                       string `pic:"1,30"`  // 30 chars, 1-30
+// 	Employees                  int    `pic:"31,39"` // 9 chars, 31-39
+// 	BusinessRegistrationNumber string `pic:"40,51"` // 12 chars 40-51
 // }
 // s := `HERARE30CHARS    OFCOMPANYNAME999999999RegistrtnNum`
 // c := &Company{}

--- a/decode.go
+++ b/decode.go
@@ -53,10 +53,10 @@ func (d *decoder) Decode(v interface{}) error {
 	}
 
 	if rv.Elem().Kind() == reflect.Slice {
-		return d.scanLines(rv.Elem())
+		return d.decodeLines(rv.Elem())
 	}
 
-	ok, err := d.scanLine(rv)
+	ok, err := d.decodeLine(rv)
 	if d.done && err == nil && !ok {
 		return io.EOF
 	}
@@ -64,46 +64,57 @@ func (d *decoder) Decode(v interface{}) error {
 	return err
 }
 
-func (d *decoder) scanLine(v reflect.Value) (bool, error) {
+// decodeLine scans the next line in the scanner, sets d.done to true if the
+// scanner has reached EOF (and returns false indicating not to continue),
+// otherwise, detecting the appropriate setter function based on the type of the
+// given value v, and unpacks a string representation of the bytes associated
+// with that line, into the object v using the identified setter function, set.
+func (d *decoder) decodeLine(v reflect.Value) (bool, error) {
+	// scan next line
 	if ok := d.s.Scan(); !ok {
-		d.done = true
+		d.done = true // reached EOF
 		return false, nil
 	}
 
-	t := v.Type()
-
-	set := newSetFunc(t, 0, 0)
-	return true, set(v, string(d.s.Bytes()))
+	// detect type to unpack line into
+	set := newSetFunc(v.Type(), 0, 0)
+	return true, set(v, string(d.s.Bytes())) // unpa
 }
 
-func (d *decoder) scanLines(v reflect.Value) (err error) {
-	ct := v.Type().Elem()
+// decodeLines iterates through each line of the scanner, builds an instance of
+// the type that the line is expected to be unpacked into, sets the type to the
+// scanned values, and appends it to the incoming object v
+func (d *decoder) decodeLines(v reflect.Value) (err error) {
+	currentType := v.Type().Elem()
 	for {
-		nv := reflect.New(ct).Elem()
-		ok, err := d.scanLine(nv)
+		newValue := reflect.New(currentType).Elem()
+		ok, err := d.decodeLine(newValue)
 		if err != nil {
 			return err
 		}
 
 		if ok {
-			v.Set(reflect.Append(v, nv))
+			v.Set(reflect.Append(v, newValue))
 		}
 
 		if d.done {
 			break
 		}
 	}
+
 	return nil
 }
 
-func newValFromLine(s string, start int, end int) string {
-	if len(s) == 0 || start > len(s) {
+// newValFromLine cuts a value out of a string line from character indices
+// start to end
+func newValFromLine(line string, start int, end int) string {
+	if len(line) == 0 || start > len(line) {
 		return ""
 	}
 
-	if end > len(s) {
-		end = len(s)
+	if end > len(line) {
+		end = len(line)
 	}
 
-	return strings.Trim(s[start-1:end], " ")
+	return strings.Trim(line[start-1:end], " ")
 }

--- a/decode.go
+++ b/decode.go
@@ -70,15 +70,13 @@ func (d *decoder) Decode(v interface{}) error {
 // given value v, and unpacks a string representation of the bytes associated
 // with that line, into the object v using the identified setter function, set.
 func (d *decoder) decodeLine(v reflect.Value) (bool, error) {
-	// scan next line
 	if ok := d.s.Scan(); !ok {
-		d.done = true // reached EOF
+		d.done = true
 		return false, nil
 	}
 
-	// detect type to unpack line into
 	set := newSetFunc(v.Type(), 0, 0)
-	return true, set(v, string(d.s.Bytes())) // unpa
+	return true, set(v, string(d.s.Bytes()))
 }
 
 // decodeLines iterates through each line of the scanner, builds an instance of

--- a/decode_test.go
+++ b/decode_test.go
@@ -41,47 +41,116 @@ func TestNewUnmarshalOmit(t *testing.T) {
 	}, in)
 }
 
+func TestUnmarshal_Other(t *testing.T) {
+	t.Run("Field Length 1", func(t *testing.T) {
+		var st = struct {
+			F1 string `pic:"1,1"`
+		}{}
+
+		err := Unmarshal([]byte("v"), &st)
+		if err != nil {
+			t.Errorf("Unmarshal() err %v", err)
+		}
+
+		if st.F1 != "v" {
+			t.Errorf("Unmarshal() want %v, have %v", "v", st.F1)
+		}
+	})
+
+	t.Run("Replicate basic OCCURS clauses", func(t *testing.T) {
+		type basicWithOccurs struct {
+			String    string `pic:"1,5"`
+			Int       int    `pic:"6,10"`
+			IntOccurs []int  `pic:"11,16,3"`
+		}
+		expect := &basicWithOccurs{"foo", 123, []int{12, 34, 56}}
+		got := &basicWithOccurs{}
+		err := Unmarshal([]byte("foo  123  123456"), got)
+		require.NoError(t, err)
+		require.Equal(t, expect, got)
+	})
+
+	t.Run("Replicate basic OCCURS clauses", func(t *testing.T) {
+		type dummy struct {
+			A int `pic:"1,1"`
+			B int `pic:"2,2"`
+		}
+		type basicWithOccursStruct struct {
+			String string  `pic:"1,5"`
+			Int    int     `pic:"6,10"`
+			Dummy  []dummy `pic:"11,16,3"`
+		}
+		expect := &basicWithOccursStruct{"foo", 123, []dummy{{A: 1, B: 2}, {A: 3, B: 4}, {A: 5, B: 6}}}
+		got := &basicWithOccursStruct{}
+		err := Unmarshal([]byte("foo  123  123456"), got)
+		require.NoError(t, err)
+		require.Equal(t, expect, got)
+	})
+
+	t.Run("Invalid Unmarshal Errors", func(t *testing.T) {
+		for _, test := range []struct {
+			name      string
+			v         interface{}
+			shouldErr bool
+		}{
+			{"Invalid Unmarshal Nil", nil, true},
+			{"Invalid Unmarshal Not Pointer 1", struct{}{}, true},
+			{"Invalid Unmarshal Not Pointer 2", []struct{}{}, true},
+			{"Valid Unmarshal slice", &[]struct{}{}, false},
+			{"Valid Unmarshal struct", &struct{}{}, true},
+		} {
+			tt := test
+			t.Run(tt.name, func(t *testing.T) {
+				err := Unmarshal([]byte{}, tt.v)
+				if tt.shouldErr != (err != nil) {
+					t.Errorf("Unmarshal() err want %v, have %v (%v)", tt.shouldErr, err != nil, err)
+				}
+			})
+		}
+	})
+}
+
 func TestUnmarshal(t *testing.T) {
 	type basicTypes struct {
-		String string  `pic:"5"`
-		Int    int     `pic:"5"`
-		Float  float64 `pic:"5"`
+		String string  `pic:"1,5"`
+		Int    int     `pic:"6,10"`
+		Float  float64 `pic:"11,15"`
 	}
 
 	type occursOffset struct {
-		A string   `pic:"13"`
-		B string   `pic:"13"`
-		C string   `pic:"13"`
-		D string   `pic:"13"`
-		E string   `pic:"13"`
-		F string   `pic:"13"`
-		G string   `pic:"2"`
-		H []string `pic:"13,12"`
+		A string   `pic:"1,13"`
+		B string   `pic:"14,26"`
+		C string   `pic:"27,39"`
+		D string   `pic:"40,52"`
+		E string   `pic:"53,65"`
+		F string   `pic:"66,78"`
+		G string   `pic:"79,80"`
+		H []string `pic:"81,236,12"`
 	}
 
 	type C struct {
-		CA []string `pic:"1,5"`
+		CA []string `pic:"1,5,5"`
 	}
 
 	type D struct {
-		DA string `pic:"2"`
+		DA string `pic:"1,2"`
 	}
 
 	type C2 struct {
-		CA []string `pic:"1,5"`
-		CB D        `pic:"2"`
+		CA []string `pic:"1,5,5"`
+		CB D        `pic:"6,7"`
 	}
 
 	type nestedStruct struct {
-		A string `pic:"13"`
-		B string `pic:"13"`
-		C C      `pic:"5"`
+		A string `pic:"1,13"`
+		B string `pic:"14,26"`
+		C C      `pic:"27,32"`
 	}
 
 	type multiNestedStruct struct {
-		A string `pic:"13"`
-		B string `pic:"13"`
-		C C2     `pic:"7"`
+		A string `pic:"1,13"`
+		B string `pic:"14,26"`
+		C C2     `pic:"27,33"`
 	}
 
 	for _, test := range []struct {
@@ -195,71 +264,4 @@ func TestUnmarshal(t *testing.T) {
 			}
 		})
 	}
-
-	t.Run("Field Length 1", func(t *testing.T) {
-		var st = struct {
-			F1 string `pic:"1"`
-		}{}
-
-		err := Unmarshal([]byte("v"), &st)
-		if err != nil {
-			t.Errorf("Unmarshal() err %v", err)
-		}
-
-		if st.F1 != "v" {
-			t.Errorf("Unmarshal() want %v, have %v", "v", st.F1)
-		}
-	})
-
-	t.Run("Replicate basic OCCURS clauses", func(t *testing.T) {
-		type basicWithOccurs struct {
-			String    string `pic:"5"`
-			Int       int    `pic:"5"`
-			IntOccurs []int  `pic:"2,3"`
-		}
-		expect := &basicWithOccurs{"foo", 123, []int{12, 34, 56}}
-		got := &basicWithOccurs{}
-		err := Unmarshal([]byte("foo  123  123456"), got)
-		require.NoError(t, err)
-		require.Equal(t, expect, got)
-	})
-
-	t.Run("Replicate basic OCCURS clauses", func(t *testing.T) {
-		type dummy struct {
-			A int `pic:"1"`
-			B int `pic:"1"`
-		}
-		type basicWithOccursStruct struct {
-			String string  `pic:"5"`
-			Int    int     `pic:"5"`
-			Dummy  []dummy `pic:"2,3"`
-		}
-		expect := &basicWithOccursStruct{"foo", 123, []dummy{{A: 1, B: 2}, {A: 3, B: 4}, {A: 5, B: 6}}}
-		got := &basicWithOccursStruct{}
-		err := Unmarshal([]byte("foo  123  123456"), got)
-		require.NoError(t, err)
-		require.Equal(t, expect, got)
-	})
-
-	t.Run("Invalid Unmarshal Errors", func(t *testing.T) {
-		for _, test := range []struct {
-			name      string
-			v         interface{}
-			shouldErr bool
-		}{
-			{"Invalid Unmarshal Nil", nil, true},
-			{"Invalid Unmarshal Not Pointer 1", struct{}{}, true},
-			{"Invalid Unmarshal Not Pointer 2", []struct{}{}, true},
-			{"Valid Unmarshal slice", &[]struct{}{}, false},
-			{"Valid Unmarshal struct", &struct{}{}, true},
-		} {
-			tt := test
-			t.Run(tt.name, func(t *testing.T) {
-				err := Unmarshal([]byte{}, tt.v)
-				if tt.shouldErr != (err != nil) {
-					t.Errorf("Unmarshal() err want %v, have %v (%v)", tt.shouldErr, err != nil, err)
-				}
-			})
-		}
-	})
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -7,6 +7,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewUnmarshal(t *testing.T) {
+	type stuff struct {
+		String string  `pic:"1,5"`
+		Int    int     `pic:"6,10"`
+		Float  float64 `pic:"11,15"`
+	}
+
+	in := &stuff{}
+	err := Unmarshal([]byte("foo  123  1.2  "), in)
+	require.NoError(t, err)
+	require.Equal(t, &stuff{
+		String: "foo",
+		Int:    123,
+		Float:  1.2,
+	}, in)
+}
+
+func TestNewUnmarshalOmit(t *testing.T) {
+	type stuff struct {
+		String string  `pic:"1,5"`
+		Int    int     `pic:"-"`
+		Float  float64 `pic:"11,15"`
+	}
+
+	in := &stuff{}
+	err := Unmarshal([]byte("foo  123  1.2  "), in)
+	require.NoError(t, err)
+	require.Equal(t, &stuff{
+		String: "foo",
+		Int:    0,
+		Float:  1.2,
+	}, in)
+}
+
 func TestUnmarshal(t *testing.T) {
 	type basicTypes struct {
 		String string  `pic:"5"`

--- a/decode_test.go
+++ b/decode_test.go
@@ -43,11 +43,11 @@ func TestUnmarshal_OmitArray(t *testing.T) {
 
 func TestUnmarshal_OmitStruct(t *testing.T) {
 	type abcde struct {
-		A int
-		B int
-		C int
-		D int
-		E int
+		A int `pic:"1,1"`
+		B int `pic:"2,2"`
+		C int `pic:"3,3"`
+		D int `pic:"4,4"`
+		E int `pic:"5,5"`
 	}
 
 	type stuff struct {

--- a/decode_test.go
+++ b/decode_test.go
@@ -41,6 +41,31 @@ func TestUnmarshal_OmitArray(t *testing.T) {
 	}, in)
 }
 
+func TestUnmarshal_OmitStruct(t *testing.T) {
+	type abcde struct {
+		A int
+		B int
+		C int
+		D int
+		E int
+	}
+
+	type stuff struct {
+		String string  `pic:"1,5"`
+		Int    abcde   `pic:"-"`
+		Float  float64 `pic:"11,15"`
+	}
+
+	in := &stuff{}
+	err := Unmarshal([]byte("foo  123  1.2  "), in)
+	require.NoError(t, err)
+	require.Equal(t, &stuff{
+		String: "foo",
+		Int:    abcde{},
+		Float:  1.2,
+	}, in)
+}
+
 func TestUnmarshal_Other(t *testing.T) {
 	t.Run("Field Length 1", func(t *testing.T) {
 		var st = struct {

--- a/decode_test.go
+++ b/decode_test.go
@@ -7,24 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewUnmarshal(t *testing.T) {
-	type stuff struct {
-		String string  `pic:"1,5"`
-		Int    int     `pic:"6,10"`
-		Float  float64 `pic:"11,15"`
-	}
-
-	in := &stuff{}
-	err := Unmarshal([]byte("foo  123  1.2  "), in)
-	require.NoError(t, err)
-	require.Equal(t, &stuff{
-		String: "foo",
-		Int:    123,
-		Float:  1.2,
-	}, in)
-}
-
-func TestNewUnmarshalOmit(t *testing.T) {
+func TestUnmarshal_Omit(t *testing.T) {
 	type stuff struct {
 		String string  `pic:"1,5"`
 		Int    int     `pic:"-"`
@@ -37,6 +20,23 @@ func TestNewUnmarshalOmit(t *testing.T) {
 	require.Equal(t, &stuff{
 		String: "foo",
 		Int:    0,
+		Float:  1.2,
+	}, in)
+}
+
+func TestUnmarshal_OmitArray(t *testing.T) {
+	type stuff struct {
+		String string  `pic:"1,5"`
+		Int    []int   `pic:"-"`
+		Float  float64 `pic:"11,15"`
+	}
+
+	in := &stuff{}
+	err := Unmarshal([]byte("foo  123  1.2  "), in)
+	require.NoError(t, err)
+	require.Equal(t, &stuff{
+		String: "foo",
+		Int:    nil,
 		Float:  1.2,
 	}, in)
 }

--- a/example/example.go
+++ b/example/example.go
@@ -8,39 +8,39 @@ package main
 
 // example contains a representation of your provided Copybook
 type example struct {
-	DUMMYGROUP1 DUMMYGROUP1 `pic:"63"`
-	DUMMYGROUP3 DUMMYGROUP3 `pic:"201"`
+	DUMMYGROUP1 DUMMYGROUP1 `pic:"1,63"`
+	DUMMYGROUP3 DUMMYGROUP3 `pic:"64,264"`
 }
 
 // DUMMYSUBGROUP1 contains a representation of the nested group DUMMY-SUB-GROUP-1
 type DUMMYSUBGROUP1 struct {
-	DUMMYGROUP1OBJECTA uint   `pic:"4"`  // start:1 end:4
-	DUMMYGROUP1OBJECTB string `pic:"1"`  // start:5 end:5
-	DUMMYGROUP1OBJECTC uint   `pic:"4"`  // start:6 end:9
-	DUMMYGROUP1OBJECTD string `pic:"40"` // start:10 end:49
-	DUMMYGROUP1OBJECTE string `pic:"8"`  // start:50 end:57
-	DUMMYGROUP1OBJECTG string `pic:"2"`  // start:58 end:59
-	DUMMYGROUP1OBJECTH uint   `pic:"4"`  // start:60 end:63
+	DUMMYGROUP1OBJECTA uint   `pic:"1,4"`   // start:1 end:4
+	DUMMYGROUP1OBJECTB string `pic:"5,5"`   // start:5 end:5
+	DUMMYGROUP1OBJECTC uint   `pic:"6,9"`   // start:6 end:9
+	DUMMYGROUP1OBJECTD string `pic:"10,49"` // start:10 end:49
+	DUMMYGROUP1OBJECTE string `pic:"50,57"` // start:50 end:57
+	DUMMYGROUP1OBJECTG string `pic:"58,59"` // start:58 end:59
+	DUMMYGROUP1OBJECTH uint   `pic:"60,63"` // start:60 end:63
 }
 
 // DUMMYGROUP1 contains a representation of the nested group DUMMY-GROUP-1
 type DUMMYGROUP1 struct {
-	DUMMYSUBGROUP1 DUMMYSUBGROUP1 `pic:"63"`
+	DUMMYSUBGROUP1 DUMMYSUBGROUP1 `pic:"1,63"`
 }
 
 // DUMMYSUBGROUP2GETSDROPPED contains a representation of the nested group DUMMY-SUBGROUP-2-GETSDROPPED
 type DUMMYSUBGROUP2GETSDROPPED struct {
-	DUMMYSUBGROUP2OBJECTA []string `pic:"12,12"` // start:97 end:240
+	DUMMYSUBGROUP2OBJECTA []string `pic:"1,144,12"` // start:97 end:240
 }
 
 // DUMMYGROUP3 contains a representation of the nested group DUMMY-GROUP-3
 type DUMMYGROUP3 struct {
-	DUMMYGROUP2OBJECTA        string                    `pic:"14"` // start:64 end:77
-	DUMMYGROUP2OBJECTB        uint                      `pic:"7"`  // start:78 end:84
-	DUMMYGROUP2OBJECTC        string                    `pic:"4"`  // start:85 end:88
-	DUMMYGROUP2OBJECTD        string                    `pic:"1"`  // start:89 end:89
-	DUMMYGROUP2OBJECTF        string                    `pic:"7"`  // start:90 end:96
-	DUMMYSUBGROUP2GETSDROPPED DUMMYSUBGROUP2GETSDROPPED `pic:"144"`
-	DUMMYGROUP2OBJECTG        string                    `pic:"12"` // start:241 end:252
-	DUMMYGROUP2OBJECTH        string                    `pic:"12"` // start:253 end:264
+	DUMMYGROUP2OBJECTA        string                    `pic:"1,14"`  // start:64 end:77
+	DUMMYGROUP2OBJECTB        uint                      `pic:"15,21"` // start:78 end:84
+	DUMMYGROUP2OBJECTC        string                    `pic:"22,25"` // start:85 end:88
+	DUMMYGROUP2OBJECTD        string                    `pic:"26,26"` // start:89 end:89
+	DUMMYGROUP2OBJECTF        string                    `pic:"27,33"` // start:90 end:96
+	DUMMYSUBGROUP2GETSDROPPED DUMMYSUBGROUP2GETSDROPPED `pic:"34,177"`
+	DUMMYGROUP2OBJECTG        string                    `pic:"178,189"` // start:241 end:252
+	DUMMYGROUP2OBJECTH        string                    `pic:"190,201"` // start:253 end:264
 }

--- a/setfunc.go
+++ b/setfunc.go
@@ -99,21 +99,20 @@ func arraySetFunc(l, count int) setFunc {
 			v.Set(reflect.MakeSlice(v.Type(), 0, 0))
 		}
 
-		many := reflect.MakeSlice(v.Type(), count, count)
+		newSlice := reflect.MakeSlice(v.Type(), count, count)
 		sf := newSetFunc(v.Type().Elem(), 0, 0)
 		track := 1
 
 		for i := 0; i < count; i++ {
 			next := track + size
 			val := newValFromLine(s, track, next-1)
-			if err := sf(many.Index(i), val); err != nil {
+			if err := sf(newSlice.Index(i), val); err != nil {
 				return errors.New("failed to set array data" + val + " " + s)
 			}
 			track = next
 		}
 
-		v.Set(many)
-
+		v.Set(newSlice)
 		return nil
 	}
 }

--- a/setfunc.go
+++ b/setfunc.go
@@ -3,6 +3,7 @@ package pic
 import (
 	"errors"
 	"fmt"
+	"log"
 	"reflect"
 	"strconv"
 )
@@ -31,6 +32,11 @@ func newSetFunc(t reflect.Type, picSize, occursSize int) setFunc {
 		return structSetFunc(t)
 	}
 	return failSetFunc
+}
+
+func skipSetFunc(_ reflect.Value, _ string) error {
+	log.Println("skipping value")
+	return nil
 }
 
 func strSetFunc(v reflect.Value, s string) error {
@@ -139,7 +145,11 @@ func structSetFunc(t reflect.Type) setFunc {
 				continue
 			}
 
-			val := newValFromLine(s, ff.start, ff.end)
+			var val string
+			if !ff.tag.skip {
+				val = newValFromLine(s, ff.tag.start, ff.tag.end)
+			}
+
 			err := ff.setFunc(v.Field(i), val)
 			if err != nil {
 				sf := t.Field(i)

--- a/tag.go
+++ b/tag.go
@@ -11,7 +11,18 @@ import (
 const (
 	// when a tag is split on ',' if there are 2 elements,
 	// the second indicates the occurs count
-	occursIndicator = 2
+	// Tag values are now accepted in the following format
+	// `pic:"-"` // ignore this field
+	// `pic:"1,2"` // start:1, end:2 (length 2)
+	// `pic:"1,2,2"` // start:1, end:2 (size 1x2)
+
+	tag          = "pic"
+	tagSeparator = ","
+	ignoreTag    = "-"
+
+	omitIndicator   = 1
+	simpleIndicator = 2
+	occursIndicator = 3
 )
 
 var fieldRepCache sync.Map // map[reflect.Type]structRepresentation
@@ -22,32 +33,71 @@ type structRepresentation struct {
 }
 
 type fieldRepresentation struct {
-	setFunc         setFunc
-	len, start, end int
-	err             error
+	setFunc setFunc
+	tag     tagRepresentation
+	err     error
 }
 
-func parseTag(tag string, prev int) (int, int, int, int, error) {
-	var occursSize int
-	ss := strings.Split(tag, ",")
-	if len(ss) == occursIndicator {
-		o, err := strconv.Atoi(ss[1])
-		if err != nil {
-			return 0, 0, 0, 0, fmt.Errorf("failed string->int conversion: %w", err)
+type tagRepresentation struct {
+	start  int
+	end    int
+	occurs int
+	length int
+	skip   bool
+}
+
+// parseTag accepts the values associated with the `pic` tag keyword, splits the
+// values based on the accepted comma separator, and unpacks accepted tag formats
+// into valid behaviours
+func parseTag(tag string) (*tagRepresentation, error) {
+	tagVals := &tagRepresentation{}
+	ss := strings.Split(tag, tagSeparator)
+	switch elemCount := len(ss); elemCount {
+	case omitIndicator:
+		if ss[0] != ignoreTag {
+			return nil, fmt.Errorf("single pic tag value provided, expected %s", ignoreTag)
 		}
-		occursSize = o
+		tagVals.skip = true
+	case simpleIndicator:
+		var err error
+		tagVals.start, tagVals.end, tagVals.length, err = getSpread(ss)
+		if err != nil {
+			return nil, err
+		}
+
+	case occursIndicator:
+		o, err := strconv.Atoi(ss[2])
+		if err != nil {
+			return nil, fmt.Errorf("failed string->int conversion: %w", err)
+		}
+		tagVals.occurs = o
+
+		tagVals.start, tagVals.end, tagVals.end, err = getSpread(ss)
+		if err != nil {
+			return nil, err
+		}
+
+		if tagVals.occurs > 0 {
+			tagVals.length *= tagVals.occurs
+		}
 	}
 
-	length, err := strconv.Atoi(ss[0])
+	return tagVals, nil
+}
+
+func getSpread(ss []string) (int, int, int, error) {
+	start, err := strconv.Atoi(ss[0])
 	if err != nil {
-		return 0, 0, 0, 0, fmt.Errorf("failed string->int conversion: %w", err)
+		return 0, 0, 0, fmt.Errorf("failed string->int conversion: %w", err)
 	}
 
-	if occursSize > 0 {
-		length *= occursSize
+	end, err := strconv.Atoi(ss[1])
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("failed string->int conversion: %w", err)
 	}
 
-	return length, prev + 1, length + prev, occursSize, nil
+	length := end - (start - 1)
+	return start, end, length, nil
 }
 
 func makeStructRepresentation(t reflect.Type) structRepresentation {
@@ -55,21 +105,21 @@ func makeStructRepresentation(t reflect.Type) structRepresentation {
 		fields: make([]fieldRepresentation, t.NumField()),
 	}
 
-	last := 0
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
+		tagVals, err := parseTag(f.Tag.Get(tag))
+		sr.fields[i].tag = *tagVals
 
-		l, s, e, occursSize, err := parseTag(f.Tag.Get("pic"), last)
-		last = e
-
-		sr.fields[i].len = l
-		sr.fields[i].start = s
-		sr.fields[i].end = e
-		sr.fields[i].err = err
-		sr.fields[i].setFunc = newSetFunc(f.Type, l, occursSize)
-		if sr.fields[i].end > sr.len {
-			sr.len = sr.fields[i].end
+		if tagVals.skip {
+			sr.fields[i].setFunc = skipSetFunc
+		} else {
+			sr.fields[i].setFunc = newSetFunc(f.Type, tagVals.length, tagVals.occurs)
 		}
+
+		if sr.fields[i].tag.end > sr.len {
+			sr.len = sr.fields[i].tag.end // TODO: validate implications when omit
+		}
+		sr.fields[i].err = err
 	}
 
 	return sr

--- a/tag.go
+++ b/tag.go
@@ -9,9 +9,7 @@ import (
 )
 
 const (
-	// when a tag is split on ',' if there are 2 elements,
-	// the second indicates the occurs count
-	// Tag values are now accepted in the following format
+	// Tag values are accepted in the following format:
 	// `pic:"-"` // ignore this field
 	// `pic:"1,2"` // start:1, end:2 (length 2)
 	// `pic:"1,2,2"` // start:1, end:2 (size 1x2)

--- a/tag.go
+++ b/tag.go
@@ -46,7 +46,7 @@ type tagRepresentation struct {
 
 // parseTag accepts the values associated with the `pic` tag keyword, splits the
 // values based on the accepted comma separator, and unpacks accepted tag formats
-// into valid behaviours
+// into valid behaviors
 func parseTag(tag string) (*tagRepresentation, error) {
 	tagVals := &tagRepresentation{}
 	ss := strings.Split(tag, tagSeparator)
@@ -70,13 +70,9 @@ func parseTag(tag string) (*tagRepresentation, error) {
 		}
 		tagVals.occurs = o
 
-		tagVals.start, tagVals.end, tagVals.end, err = getSpread(ss)
+		tagVals.start, tagVals.end, tagVals.length, err = getSpread(ss)
 		if err != nil {
 			return nil, err
-		}
-
-		if tagVals.occurs > 0 {
-			tagVals.length *= tagVals.occurs
 		}
 	}
 

--- a/tag.go
+++ b/tag.go
@@ -13,7 +13,6 @@ const (
 	// `pic:"-"` // ignore this field
 	// `pic:"1,2"` // start:1, end:2 (length 2)
 	// `pic:"1,2,2"` // start:1, end:2 (size 1x2)
-
 	tag          = "pic"
 	tagSeparator = ","
 	ignoreTag    = "-"
@@ -30,12 +29,17 @@ type structRepresentation struct {
 	fields []fieldRepresentation
 }
 
+// fieldRepresentation is a collection of a field/property's tag values,
+// relevant determined setFunc and any error collected when building the
+// representation
 type fieldRepresentation struct {
 	setFunc setFunc
 	tag     tagRepresentation
 	err     error
 }
 
+// tagRepresentation is a collection of all tag values associated with a field/
+// property
 type tagRepresentation struct {
 	start  int
 	end    int
@@ -79,6 +83,7 @@ func parseTag(tag string) (*tagRepresentation, error) {
 	return tagVals, nil
 }
 
+// getSpread returns the start, end, and length of an evaluated tag's values
 func getSpread(ss []string) (int, int, int, error) {
 	start, err := strconv.Atoi(ss[0])
 	if err != nil {
@@ -111,7 +116,7 @@ func makeStructRepresentation(t reflect.Type) structRepresentation {
 		}
 
 		if sr.fields[i].tag.end > sr.len {
-			sr.len = sr.fields[i].tag.end // TODO: validate implications when omit
+			sr.len = sr.fields[i].tag.end
 		}
 		sr.fields[i].err = err
 	}
@@ -119,7 +124,8 @@ func makeStructRepresentation(t reflect.Type) structRepresentation {
 	return sr
 }
 
-// cachedStructRepresentation is like makeStructRepresentation but cached to prevent duplicate work.
+// cachedStructRepresentation is like makeStructRepresentation but cached to
+// prevent duplicate work.
 func cachedStructRepresentation(t reflect.Type) structRepresentation {
 	if f, ok := fieldRepCache.Load(t); ok {
 		return f.(structRepresentation)


### PR DESCRIPTION
Fixes #44

## Description

This PR includes the following changes:
- Rely on start/end tag values for unmarshalling again
- enable omit indicator "-"
- enable generation of start/end tag values

## Acceptance Criteria

Required: 
 - [x] Unit tests
 
Prompts:
 - [x] GoDoc
 - [ ] Readme
